### PR TITLE
Feature updates

### DIFF
--- a/TorrentHardLinkHelper.Library/HardLink/HardLinkHelper.cs
+++ b/TorrentHardLinkHelper.Library/HardLink/HardLinkHelper.cs
@@ -166,5 +166,198 @@ namespace TorrentHardLinkHelper.HardLink
             this._builder.AppendLine(string.Format("mkdir  \"{0}\"", path));
             Directory.CreateDirectory(path);
         }
+
+        public void GenerateLinuxSymlinkScript(IList<TorrentFileLink> links, string folderName, string baseFolder, string sourceFolder)
+        {
+            this._builder = new StringBuilder();
+            this._builder.AppendLine("#!/bin/bash");
+            this._builder.AppendLine("#==============================================");
+            this._builder.AppendLine("# Torrent Hard-Link Helper - Linux Symlink Script");
+            this._builder.AppendLine("#");
+            this._builder.AppendLine("# Created at " + DateTime.Now);
+            this._builder.AppendLine("#==============================================");
+            this._builder.AppendLine("");
+            this._builder.AppendLine("# Change to the script directory");
+            this._builder.AppendLine("cd \"$(dirname \"$0\")\"");
+            this._builder.AppendLine("");
+
+            // Create base folder
+            string linuxFolderName = ToLinuxPath(folderName);
+            this._builder.AppendLine(string.Format("mkdir -p \"{0}\"", linuxFolderName));
+            this._builder.AppendLine("");
+
+            // Track directories we've already added mkdir commands for
+            var createdLinuxDirs = new HashSet<string>();
+
+            foreach (var link in links)
+            {
+                if (link.LinkedFsFileInfo == null)
+                {
+                    continue;
+                }
+
+                // Create subdirectories inside base folder
+                string[] pathParts = link.TorrentFile.Path.Split('\\');
+                if (pathParts.Length > 1)
+                {
+                    string linuxDirPath = linuxFolderName + "/" + ToLinuxPath(string.Join("\\", pathParts, 0, pathParts.Length - 1));
+                    
+                    if (!createdLinuxDirs.Contains(linuxDirPath))
+                    {
+                        this._builder.AppendLine(string.Format("mkdir -p \"{0}\"", linuxDirPath));
+                        createdLinuxDirs.Add(linuxDirPath);
+                    }
+                }
+
+                // Calculate relative path from target location to source file
+                string linuxTargetPath = linuxFolderName + "/" + ToLinuxPath(link.TorrentFile.Path);
+                string relativePath = GetRelativeSourcePath(link.TorrentFile.Path, link.LinkedFsFileInfo.FilePath, sourceFolder);
+
+                this._builder.AppendLine(string.Format("ln -s \"{0}\" \"{1}\"", relativePath, linuxTargetPath));
+            }
+
+            var utf8nobom = new UTF8Encoding(false);
+            string scriptContent = this._builder.ToString().Replace("\r\n", "\n");
+            File.WriteAllText(Path.Combine(baseFolder, folderName + "_symlink.sh"), scriptContent, utf8nobom);
+        }
+
+        public void GenerateLinuxMoveScript(IList<TorrentFileLink> links, string folderName, string baseFolder, string sourceFolder)
+        {
+            this._builder = new StringBuilder();
+            this._builder.AppendLine("#!/bin/bash");
+            this._builder.AppendLine("#==============================================");
+            this._builder.AppendLine("# Torrent Hard-Link Helper - Linux Move Script");
+            this._builder.AppendLine("#");
+            this._builder.AppendLine("# Created at " + DateTime.Now);
+            this._builder.AppendLine("#==============================================");
+            this._builder.AppendLine("");
+            this._builder.AppendLine("# Change to the script directory");
+            this._builder.AppendLine("cd \"$(dirname \"$0\")\"");
+            this._builder.AppendLine("");
+
+            // Create base folder
+            string linuxFolderName = ToLinuxPath(folderName);
+            this._builder.AppendLine(string.Format("mkdir -p \"{0}\"", linuxFolderName));
+            this._builder.AppendLine("");
+
+            // Track directories we've already added mkdir commands for
+            var createdLinuxDirs = new HashSet<string>();
+
+            foreach (var link in links)
+            {
+                if (link.LinkedFsFileInfo == null)
+                {
+                    continue;
+                }
+
+                // Create subdirectories inside base folder
+                string[] pathParts = link.TorrentFile.Path.Split('\\');
+                if (pathParts.Length > 1)
+                {
+                    string linuxDirPath = linuxFolderName + "/" + ToLinuxPath(string.Join("\\", pathParts, 0, pathParts.Length - 1));
+                    
+                    if (!createdLinuxDirs.Contains(linuxDirPath))
+                    {
+                        this._builder.AppendLine(string.Format("mkdir -p \"{0}\"", linuxDirPath));
+                        createdLinuxDirs.Add(linuxDirPath);
+                    }
+                }
+
+                // Get source path relative to source folder
+                string sourceRelative = link.LinkedFsFileInfo.FilePath.Substring(sourceFolder.Length).TrimStart('\\');
+                string sourceFolderName = Path.GetFileName(sourceFolder);
+                string linuxSourcePath = sourceFolderName + "/" + ToLinuxPath(sourceRelative);
+                string linuxTargetPath = linuxFolderName + "/" + ToLinuxPath(link.TorrentFile.Path);
+
+                this._builder.AppendLine(string.Format("mv \"{0}\" \"{1}\"", linuxSourcePath, linuxTargetPath));
+            }
+
+            var utf8nobom = new UTF8Encoding(false);
+            string scriptContent = this._builder.ToString().Replace("\r\n", "\n");
+            File.WriteAllText(Path.Combine(baseFolder, folderName + "_move.sh"), scriptContent, utf8nobom);
+        }
+
+        public void GenerateLinuxHardlinkScript(IList<TorrentFileLink> links, string folderName, string baseFolder, string sourceFolder)
+        {
+            this._builder = new StringBuilder();
+            this._builder.AppendLine("#!/bin/bash");
+            this._builder.AppendLine("#==============================================");
+            this._builder.AppendLine("# Torrent Hard-Link Helper - Linux Hard Link Script");
+            this._builder.AppendLine("#");
+            this._builder.AppendLine("# Created at " + DateTime.Now);
+            this._builder.AppendLine("#==============================================");
+            this._builder.AppendLine("");
+            this._builder.AppendLine("# Change to the script directory");
+            this._builder.AppendLine("cd \"$(dirname \"$0\")\"");
+            this._builder.AppendLine("");
+
+            // Create base folder
+            string linuxFolderName = ToLinuxPath(folderName);
+            this._builder.AppendLine(string.Format("mkdir -p \"{0}\"", linuxFolderName));
+            this._builder.AppendLine("");
+
+            // Track directories we've already added mkdir commands for
+            var createdLinuxDirs = new HashSet<string>();
+
+            foreach (var link in links)
+            {
+                if (link.LinkedFsFileInfo == null)
+                {
+                    continue;
+                }
+
+                // Create subdirectories inside base folder
+                string[] pathParts = link.TorrentFile.Path.Split('\\');
+                if (pathParts.Length > 1)
+                {
+                    string linuxDirPath = linuxFolderName + "/" + ToLinuxPath(string.Join("\\", pathParts, 0, pathParts.Length - 1));
+                    
+                    if (!createdLinuxDirs.Contains(linuxDirPath))
+                    {
+                        this._builder.AppendLine(string.Format("mkdir -p \"{0}\"", linuxDirPath));
+                        createdLinuxDirs.Add(linuxDirPath);
+                    }
+                }
+
+                // Get source path relative to source folder
+                string sourceRelative = link.LinkedFsFileInfo.FilePath.Substring(sourceFolder.Length).TrimStart('\\');
+                string sourceFolderName = Path.GetFileName(sourceFolder);
+                string linuxSourcePath = sourceFolderName + "/" + ToLinuxPath(sourceRelative);
+                string linuxTargetPath = linuxFolderName + "/" + ToLinuxPath(link.TorrentFile.Path);
+
+                this._builder.AppendLine(string.Format("ln \"{0}\" \"{1}\"", linuxSourcePath, linuxTargetPath));
+            }
+
+            var utf8nobom = new UTF8Encoding(false);
+            string scriptContent = this._builder.ToString().Replace("\r\n", "\n");
+            File.WriteAllText(Path.Combine(baseFolder, folderName + "_hardlink.sh"), scriptContent, utf8nobom);
+        }
+
+        private string GetRelativeSourcePath(string torrentFilePath, string sourceFile, string sourceFolder)
+        {
+            // Calculate how many directories deep the target file is (add 1 for the base folder)
+            string[] pathParts = torrentFilePath.Split('\\');
+            int depth = pathParts.Length; // includes base folder level
+
+            // Build the relative path prefix (../ for each level)
+            StringBuilder relativePath = new StringBuilder();
+            for (int i = 0; i < depth; i++)
+            {
+                relativePath.Append("../");
+            }
+
+            // Get the source file path relative to source folder
+            string sourceRelative = sourceFile.Substring(sourceFolder.Length).TrimStart('\\');
+            string linuxSourceRelative = ToLinuxPath(sourceRelative);
+            
+            // Combine with source folder name
+            string sourceFolderName = Path.GetFileName(sourceFolder);
+            return relativePath.ToString() + sourceFolderName + "/" + linuxSourceRelative;
+        }
+
+        private string ToLinuxPath(string windowsPath)
+        {
+            return windowsPath.Replace('\\', '/');
+        }
     }
 }

--- a/TorrentHardLinkHelper/App.xaml
+++ b/TorrentHardLinkHelper/App.xaml
@@ -1,4 +1,6 @@
-﻿<Application StartupUri="Views\MainWindow.xaml" xmlns:vm="clr-namespace:TorrentHardLinkHelper.ViewModels" 
+﻿<Application x:Class="TorrentHardLinkHelper.App"
+             StartupUri="Views/MainWindow.xaml"
+             xmlns:vm="clr-namespace:TorrentHardLinkHelper.ViewModels" 
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/TorrentHardLinkHelper/App.xaml.cs
+++ b/TorrentHardLinkHelper/App.xaml.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
+using System.IO;
 using System.Linq;
 using System.Windows;
+using TorrentHardLinkHelper.ViewModels;
 
 namespace TorrentHardLinkHelper
 {
@@ -12,5 +14,12 @@ namespace TorrentHardLinkHelper
     /// </summary>
     public partial class App : Application
     {
+        public static string[] StartupArgs { get; private set; }
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            StartupArgs = e.Args;
+        }
     }
 }

--- a/TorrentHardLinkHelper/Views/HardLinkTool.xaml
+++ b/TorrentHardLinkHelper/Views/HardLinkTool.xaml
@@ -16,7 +16,7 @@
             <ColumnDefinition Width="*"></ColumnDefinition>
             <ColumnDefinition Width="Auto"></ColumnDefinition>
         </Grid.ColumnDefinitions>
-        <TextBlock  FontWeight="Bold" Grid.Row="0" Grid.ColumnSpan="3" Margin="10" TextWrapping="Wrap" >This tool help create a copy of a folder, the size of file below 1M will be copyed, others will be hard-linked.</TextBlock>
+        <TextBlock  FontWeight="Bold" Grid.Row="0" Grid.ColumnSpan="3" Margin="10" TextWrapping="Wrap" >This tool helps to create a copy of a folder, the size of file below 1M will be copied, others will be hard-linked.</TextBlock>
         <Label Grid.Row="1" HorizontalContentAlignment="Right" VerticalAlignment="Center">Source Folder</Label>
         <Label Grid.Row="2" HorizontalContentAlignment="Right" VerticalAlignment="Center">Target Parent Folder</Label>
         <Label Grid.Row="3" HorizontalContentAlignment="Right" VerticalAlignment="Center">Target Folder Name</Label>

--- a/TorrentHardLinkHelper/Views/MainWindow.xaml
+++ b/TorrentHardLinkHelper/Views/MainWindow.xaml
@@ -28,9 +28,12 @@
             <Label Grid.Row="0" Grid.Column="0" Content="Torrent File:" HorizontalContentAlignment="Right" VerticalAlignment="Center"></Label>
             <Label Grid.Row="1" Grid.Column="0" Content="Source Folder:" HorizontalContentAlignment="Right" VerticalAlignment="Center"></Label>
             <Label Grid.Row="2" Grid.Column="0" Content="Output BaseFolder:" HorizontalContentAlignment="Right" VerticalAlignment="Center"></Label>
-            <TextBox Grid.Row="0" Grid.Column="1" Margin="5" VerticalContentAlignment="Center" Text="{Binding TorrentFile}"></TextBox>
-            <TextBox Grid.Row="1" Grid.Column="1" Margin="5" VerticalContentAlignment="Center" Text="{Binding SourceFolder}"></TextBox>
-            <TextBox Grid.Row="2" Grid.Column="1" Margin="5" VerticalContentAlignment="Center" Text="{Binding OutputBaseFolder}"></TextBox>
+            <TextBox Grid.Row="0" Grid.Column="1" Margin="5" VerticalContentAlignment="Center" Text="{Binding TorrentFile}" 
+                     AllowDrop="True" PreviewDragOver="TextBox_PreviewDragOver" Drop="TorrentFile_Drop"></TextBox>
+            <TextBox Grid.Row="1" Grid.Column="1" Margin="5" VerticalContentAlignment="Center" Text="{Binding SourceFolder}"
+                     AllowDrop="True" PreviewDragOver="TextBox_PreviewDragOver" Drop="SourceFolder_Drop"></TextBox>
+            <TextBox Grid.Row="2" Grid.Column="1" Margin="5" VerticalContentAlignment="Center" Text="{Binding OutputBaseFolder}"
+                     AllowDrop="True" PreviewDragOver="TextBox_PreviewDragOver" Drop="OutputBaseFolder_Drop"></TextBox>
             <Button Grid.Row="0" Grid.Column="2" Content="Select" Margin="5" Padding="10,5" Command="{Binding SelectTorrentFileCommand}"></Button>
             <Button Grid.Row="1" Grid.Column="2" Content="Select" Margin="5" Padding="10,5" Command="{Binding SelectSourceFolder}"></Button>
             <Button Grid.Row="2" Grid.Column="2" Content="Select" Margin="5" Padding="10,5" Command="{Binding SelectOutputBaseFolder}"></Button>
@@ -101,6 +104,9 @@
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button Content="Analyse" Padding="10,5" Margin="5" Command="{Binding AnalyseCommand}"></Button>
             <Button Content="Hard-Link" Padding="10,5" Margin="5" Command="{Binding LinkCommand}"></Button>
+            <Button Content="Soft-Link Linux" Padding="10,5" Margin="5" Command="{Binding LinkLinuxCommand}"></Button>
+            <Button Content="Hard-Link Linux" Padding="10,5" Margin="5" Command="{Binding HardlinkLinuxCommand}"></Button>
+            <Button Content="Move Linux" Padding="10,5" Margin="5" Command="{Binding MoveLinuxCommand}"></Button>
         </StackPanel>
         <StatusBar Grid.Row="4" Margin="0,10,0,0">
             <StatusBarItem>

--- a/TorrentHardLinkHelper/Views/MainWindow.xaml.cs
+++ b/TorrentHardLinkHelper/Views/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -11,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using TorrentHardLinkHelper.ViewModels;
 
 namespace TorrentHardLinkHelper.Views
 {
@@ -22,6 +24,106 @@ namespace TorrentHardLinkHelper.Views
         public MainWindow()
         {
             InitializeComponent();
+            this.Loaded += MainWindow_Loaded;
+        }
+
+        private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Process command line arguments
+            var args = App.StartupArgs;
+            if (args != null && args.Length > 0)
+            {
+                var viewModel = DataContext as MainViewModel;
+                if (viewModel != null)
+                {
+                    // First argument: torrent file
+                    if (File.Exists(args[0]) && args[0].EndsWith(".torrent", StringComparison.OrdinalIgnoreCase))
+                    {
+                        viewModel.LoadTorrentFile(args[0]);
+                    }
+
+                    // Second argument: source folder
+                    if (args.Length > 1 && Directory.Exists(args[1]))
+                    {
+                        viewModel.LoadSourceFolder(args[1]);
+                    }
+
+                    // Third argument: output base folder
+                    if (args.Length > 2 && Directory.Exists(args[2]))
+                    {
+                        viewModel.LoadOutputBaseFolder(args[2]);
+                    }
+                }
+            }
+        }
+
+        private void TextBox_PreviewDragOver(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                e.Effects = DragDropEffects.Copy;
+                e.Handled = true;
+            }
+        }
+
+        private void TorrentFile_Drop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files.Length > 0)
+                {
+                    string file = files[0];
+                    if (File.Exists(file) && file.EndsWith(".torrent", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var viewModel = DataContext as MainViewModel;
+                        if (viewModel != null)
+                        {
+                            viewModel.LoadTorrentFile(file);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void SourceFolder_Drop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files.Length > 0)
+                {
+                    string path = files[0];
+                    if (Directory.Exists(path))
+                    {
+                        var viewModel = DataContext as MainViewModel;
+                        if (viewModel != null)
+                        {
+                            viewModel.LoadSourceFolder(path);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void OutputBaseFolder_Drop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files.Length > 0)
+                {
+                    string path = files[0];
+                    if (Directory.Exists(path))
+                    {
+                        var viewModel = DataContext as MainViewModel;
+                        if (viewModel != null)
+                        {
+                            viewModel.LoadOutputBaseFolder(path);
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Color:
Files are matched by size, then path.
If exactly one match => green
If no matches at all => blue
Multiple matches with same size but different hash => red

Input:
Textboxes for torrent and folders now accept drag'n'drop. Starting program with arguments will be parsed as the first 3 textboxes.

Linking in linux:
Support soft/hard-link, as well as move the source to target base folder, by generated shell script.

Fixes:
Activate execute buttons on analyse finish.
Typos.